### PR TITLE
Bug 935489 - mozilla-download should always display the downloaded URL r...

### DIFF
--- a/lib/download.js
+++ b/lib/download.js
@@ -32,7 +32,7 @@ function download(path, options, callback) {
 
   function saveToTemp(err, url) {
     if (err) return callback(err);
-    debug('got ftp download location', url);
+    console.log('Will download at url', url);
 
     tmp.file({ prefix: 'mozilla-download-' + os }, function(err, tmpPath) {
       if (err) return callback(err);


### PR DESCRIPTION
...=jlal
