### PR TITLE
Update babel to babel-cli.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,19 +4,16 @@
   "description": "Download firefox/b2g-desktop runtimes",
   "license": "MIT",
   "main": "bin/mozilla-download",
-
   "bin": {
     "mozilla-download": "./bin/mozilla-download"
   },
-
   "contributors": [
     "Gareth Aye [:gaye] <gaye@mozilla.com>",
     "James Lal [:lightsofapollo] <jlal@mozilla.com>"
   ],
-
-  "dependencies" : {
+  "dependencies": {
     "argparse": "1.0.2",
-    "babel": "4.7.16",
+    "babel-cli": "^6.24.1",
     "debug": "2.1.3",
     "dmg": "0.0.3",
     "lodash": "3.6.0",
@@ -27,18 +24,15 @@
     "taskcluster-client": "0.21.2",
     "tmp": "0.0.25"
   },
-
   "devDependencies": {
     "chai": "2.1.2",
-    "mocha": "2.2.1",
+    "mocha": "^3.4.2",
     "node-static": "0.7.6"
   },
-
   "repository": {
     "type": "git",
     "url": "https://github.com/mozilla-b2g/mozilla-download.git"
   },
-
   "scripts": {
     "prepublish": "mkdir -p build && ./node_modules/.bin/babel src --experimental --modules common --out-dir build --source-maps",
     "test": "./node_modules/.bin/mocha"


### PR DESCRIPTION
Silences the following warning:

```
npm WARN deprecated minimatch@0.2.14: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
```

NOTE: I ran `npm run prepublish` to test this. I'm unable to run `npm test`, either before or after the change, because of the await/async syntax in the tests. I'm not sure how to pre-transpile the tests before running.